### PR TITLE
art_bridge publishing z coord of detected objects

### DIFF
--- a/art_bridge/src/bridge_to_json_msg.py
+++ b/art_bridge/src/bridge_to_json_msg.py
@@ -27,7 +27,7 @@ class BridgeToJsonMsg:
         for obj in detected_object.instances:
             '''to_json = {'name': obj.object_id, 'pose': {'position': {'x': obj.pose.position.x,
                                                                          'y': obj.pose.position.y,
-                                                                         'z': 0},
+                                                                         'z': obj.pose.position.z},
                                                             'orientation': {'x': obj.pose.orientation.x,
                                                                             'y': obj.pose.orientation.y,
                                                                             'z': obj.pose.orientation.z,
@@ -40,16 +40,16 @@ class BridgeToJsonMsg:
                 continue
             to_json = {'name': obj.object_id,
                        'type': obj.object_type,
-                       'position': {'x': obj.pose.position.x * 1000,  # meters to millimeters
-                                    'y': obj.pose.position.y * 1000,
-                                    'z': 0},
+                       'position': {'x': obj.pose.position.x,  #in meters 
+                                    'y': obj.pose.position.y,
+                                    'z': obj.pose.position.z},
                        'orientation': {'x': obj.pose.orientation.x,
                                        'y': obj.pose.orientation.y,
                                        'z': obj.pose.orientation.z,
                                        'w': obj.pose.orientation.w},
-                       'bbox': {'x': resp.object_type.bbox.dimensions[0] * 1000,
-                                'y': resp.object_type.bbox.dimensions[1] * 1000,
-                                'z': resp.object_type.bbox.dimensions[2] * 1000}}
+                       'bbox': {'x': resp.object_type.bbox.dimensions[0],
+                                'y': resp.object_type.bbox.dimensions[1],
+                                'z': resp.object_type.bbox.dimensions[2]}}
             objects.append(to_json)
         self.pub.publish(jsonpickle.encode(objects))
 

--- a/art_pr2_moveit_config/config/pr2.srdf
+++ b/art_pr2_moveit_config/config/pr2.srdf
@@ -74,7 +74,7 @@
         <joint name="l_shoulder_lift_joint" value="0.2678" />
         <joint name="l_shoulder_pan_joint" value="1.5056" />
         <joint name="l_upper_arm_roll_joint" value="0.2042" />
-        <joint name="l_wrist_flex_joint" value="-1.1648" />
+        <joint name="l_wrist_flex_joint" value="0" />
         <joint name="l_wrist_roll_joint" value="0" />
     </group_state>
     <group_state name="up_right_arm" group="right_arm">
@@ -83,7 +83,7 @@
         <joint name="r_shoulder_lift_joint" value="0.2678" />
         <joint name="r_shoulder_pan_joint" value="-1.5056" />
         <joint name="r_upper_arm_roll_joint" value="-0.2042" />
-        <joint name="r_wrist_flex_joint" value="-1.1648" />
+        <joint name="r_wrist_flex_joint" value="0" />
         <joint name="r_wrist_roll_joint" value="0" />
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->


### PR DESCRIPTION
Repaired art_bridge.. it was not publishing z coordinate of detected objects. Repaired pr2 moveit config -
pr2.srdf (pr2 grippers no longer blocks the view of kinects when calibrating).